### PR TITLE
Fixencryption

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,16 @@ jobs:
           command: |
             cd cmd
             go test
+    integration_test:
+      docker:
+        - image: circleci/golang:1.12
+      steps:
+        - checkout
+        - run:
+            name: Run integration tests
+            command: |
+              cd integration
+              go test -all
   build:
     docker:
       - image: circleci/golang:1.12
@@ -43,10 +53,15 @@ workflows:
   test-and-publish:
     jobs:
       - unit_test
+      - integration_test
+          filters:
+            branches:
+              only: integrationtesting
       - build
       - publish:
           requires:
             - unit_test
+            - integration_test
             - build
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,16 +10,16 @@ jobs:
           command: |
             cd cmd
             go test
-    integration_test:
-      docker:
-        - image: circleci/golang:1.12
-      steps:
-        - checkout
-        - run:
-            name: Run integration tests
-            command: |
-              cd integration
-              go test -all
+  integration_test:
+    docker:
+      - image: circleci/golang:1.12
+    steps:
+      - checkout
+      - run:
+          name: Run integration tests
+          command: |
+            cd integration
+            go test -all
   build:
     docker:
       - image: circleci/golang:1.12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,6 @@ workflows:
           requires:
             - unit_test
             - integration_test
-            - build
           filters:
             branches:
               only: integrationtesting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,12 +53,7 @@ workflows:
   test-and-publish:
     jobs:
       - unit_test
-      - integration_test:
-          requires:
-            - integration_test
-          filters:
-            branches:
-              only: integrationtesting
+      - integration_test    
       - build
       - publish:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,10 +53,8 @@ workflows:
   test-and-publish:
     jobs:
       - unit_test
-      - integration_test
-      - integration:
+      - integration_test:
           requires:
-            - unit_test
             - integration_test
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,10 @@ workflows:
     jobs:
       - unit_test
       - integration_test
+          requires:
+            - unit_test
+            - integration_test
+            - build
           filters:
             branches:
               only: integrationtesting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ workflows:
     jobs:
       - unit_test
       - integration_test
+      - integration:
           requires:
             - unit_test
             - integration_test
@@ -65,7 +66,6 @@ workflows:
       - publish:
           requires:
             - unit_test
-            - integration_test
             - build
           filters:
             branches:

--- a/cmd/aws_interface.go
+++ b/cmd/aws_interface.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3crypto"
+	crosscrypto "github.com/stelligent/crossing-go/crypto"
+)
+
+// S3EncryptionClient creates a new client for encryption
+var (
+	// Initialize global session
+	sess = session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+)
+
+//S3ClientPutAPI puts encrypted objects in S3
+type S3ClientPutAPI interface {
+	PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error)
+}
+
+//S3DecryptionClientAPI gets and decrypts objects in S3
+type S3DecryptionClientAPI interface {
+	GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error)
+}
+
+//NewEncryptionClient returns a new encryption client
+func NewEncryptionClient(cmkID string) S3ClientPutAPI {
+	handler := s3crypto.NewKMSKeyGenerator(kms.New(sess), cmkID)
+	cipher := s3crypto.AESCBCContentCipherBuilder(handler, crosscrypto.NewPKCS7Padder(16))
+	svc := s3crypto.NewEncryptionClient(sess, cipher)
+	return svc
+}
+
+//NewDecryptionClient returns a new decryption client
+func NewDecryptionClient() S3DecryptionClientAPI {
+	svc := s3crypto.NewDecryptionClient(sess)
+	svc.CEKRegistry[crosscrypto.AESCBCPKCS5Padding] = crosscrypto.NewAESCBCContentCipher
+	return svc
+}

--- a/cmd/aws_interface_test.go
+++ b/cmd/aws_interface_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import "github.com/aws/aws-sdk-go/service/s3"
+
+// MockS3ClientPutAPI represents S3EncryptionClient
+type MockS3ClientPutAPI struct {
+	PutObjectOutput *s3.PutObjectOutput
+}
+
+func (m *MockS3ClientPutAPI) PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	return m.PutObjectOutput, nil
+}
+
+type MockS3DecryptionClientAPI struct {
+	GetObjectOutput *s3.GetObjectOutput
+}
+
+func (m *MockS3DecryptionClientAPI) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	return m.GetObjectOutput, nil
+}

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -7,40 +7,31 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
-
-type mockGetObjectOutput struct {
-	s3iface.S3API
-	Output s3.GetObjectOutput
-}
-
-func (m mockGetObjectOutput) GetObject(in *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
-	return &m.Output, nil
-}
 
 func TestGet_getS3Cse(t *testing.T) {
 
 	cases := []struct {
-		Output   s3.GetObjectOutput
-		Expected []byte
+		S3Decrypt *MockS3DecryptionClientAPI
+		Expected  []byte
 	}{
-		{ // Case 1, expect successful output
-			Output: s3.GetObjectOutput{
-				Body: ioutil.NopCloser(bytes.NewBuffer([]byte("Hello"))),
+		{ // Case 1, expect successful write
+			S3Decrypt: &MockS3DecryptionClientAPI{
+				GetObjectOutput: &s3.GetObjectOutput{
+					Body: ioutil.NopCloser(bytes.NewBuffer([]byte("Hello"))),
+				},
 			},
 			Expected: []byte("Hello"),
 		},
 	}
 
 	for i, tt := range cases {
-		g := Get{
-			Client:          mockGetObjectOutput{Output: tt.Output},
+		g := &GetObject{
 			Bucket:          fmt.Sprintf("mockBUCKET_%d", i),
 			Key:             fmt.Sprintf("mockKEY_%d", i),
 			FileDestination: fmt.Sprintf("mockDESTINATION_%d", i),
 		}
-		content, err := g.getS3Cse()
+		content, err := GetS3Cse(g, tt.S3Decrypt)
 		if err != nil {
 			t.Fatalf("Unexpected error, %v", err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -49,15 +48,9 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	}
 
-	// Initialize global encryption client and decryption client
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}))
-
-	viper.SetConfigName(".crossing-go")  // name of config file (without extension)
-	viper.AddConfigPath("$HOME")         // adding home directory as first search path
-	viper.SetDefault("ClientSess", sess) // set global session to pass around
-	viper.AutomaticEnv()                 // read in environment variables that match
+	viper.SetConfigName(".crossing-go") // name of config file (without extension)
+	viper.AddConfigPath("$HOME")        // adding home directory as first search path
+	viper.AutomaticEnv()                // read in environment variables that match
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/aws/aws-sdk-go v1.19.41
 	github.com/spf13/cobra v0.0.4
 	github.com/spf13/viper v1.4.0
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/testify v1.3.0
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -95,9 +96,13 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0 h1:yXHLWeravcrgGyFSyCgdYpXQ9dR9c/WED3pg1RhxqEU=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/integration/main_integration_test.go
+++ b/integration/main_integration_test.go
@@ -1,0 +1,31 @@
+package integration
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+var (
+	all = flag.Bool("all", false, "run all integration tests")
+	put = flag.Bool("put", false, "run put integration tests")
+)
+
+func TestMain(t *testing.M) {
+	flag.Parse()
+
+	if *all {
+		*put = true
+	}
+
+	if *put {
+		SetupPut()
+	}
+
+	result := t.Run()
+
+	if *put {
+		PutCleanUp()
+	}
+	os.Exit(result)
+}

--- a/integration/put_integration_test.go
+++ b/integration/put_integration_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"math/rand"
@@ -9,7 +8,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-	"unicode/utf8"
 	"unsafe"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -17,10 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3crypto"
-	crosscrypto "github.com/stelligent/crossing-go/crypto"
-	"github.com/stelligent/crossing-go/cmd/Put"
-
+	"github.com/stelligent/crossing-go/cmd"
 )
 
 var (
@@ -33,57 +28,16 @@ var (
 
 //TestPutIntegration will test putS3Cse for a return value of a valid UTF-8 encoded version id
 func TestPutIntegration(t *testing.T) {
-	//Open file
-	file, err := os.Open(source)
-
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "err opening file: %s", err)
-	}
-
-	defer file.Close()
-
-	fileInfo, _ := file.Stat()
-	size := fileInfo.Size()
-
-	//Return an encryption client from the global session
-	cmkID := kmsKey
-	newSess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-east-2")},
-	)
-	//Create the KeyProvider
-	handler := s3crypto.NewKMSKeyGenerator(kms.New(newSess), cmkID)
-	cipher := s3crypto.AESCBCContentCipherBuilder(handler, crosscrypto.NewPKCS7Padder(16))
-	svc := s3crypto.NewEncryptionClient(newSess, cipher)
-	encryptionclient := &cmd.Put{
-		Client:   svc.S3Client,
-		Bucket:   bucketName,
-		Key:      key,
-		Source:   source,
-		Reader:   bufio.NewReader(file),
-		ByteSize: int(size),
-	}
-
-	args := []struct {
-		bucket     string
-		file       string
-		kmskeyid   string
-		filesource string
-		isEncoded  bool
-	}{
-		{bucketName, key, kmsKey, source, true},
-	}
-
-	for _, arg := range args {
-		vstring, err := putS3Cse()
-		isvalid := utf8.Valid(vstring)
-		if err != nil {
-			t.Errorf("Error occured: %v", err)
-		} else if len(vstring) < 0 {
-			t.Errorf("No version string was returned")
-		} else if isvalid == true {
-			t.Logf("Success! %v", vstring)
-		}
-	}
+	var arguments []string
+	destination := "s3://" + bucketName + "/" + key
+	arguments = append(arguments, "put")
+	arguments = append(arguments, "-V")
+	arguments = append(arguments, "-k")
+	arguments = append(arguments, kmsKey)
+	arguments = append(arguments, source)
+	arguments = append(arguments, destination)
+	cmd.RootCmd.SetArgs(arguments)
+	cmd.Execute()
 }
 
 //SetupPut sets up an S3 Bucket, KMS key, and writes a file for Put integration testing

--- a/integration/put_integration_test.go
+++ b/integration/put_integration_test.go
@@ -45,7 +45,7 @@ func SetupPut() {
 	)
 
 	setUpBucket(sess, bucketName)
-	kmsKey = setupKmsKey(sess, prefix)
+	kmsKey = setupKmsKey(sess)
 
 	if err != nil {
 		exitErrorf("Unable to create session", err)
@@ -55,7 +55,6 @@ func SetupPut() {
 
 func exitErrorf(msg string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, msg+"\n", args...)
-	os.Exit(1)
 }
 
 func setUpBucket(sess *session.Session, bucketName string) {
@@ -159,7 +158,7 @@ func randStringBytesMaskImprSrcUnsafe(n int) string {
 }
 
 //Setup KMS key
-func setupKmsKey(sess *session.Session, prefix string) string {
+func setupKmsKey(sess *session.Session) string {
 	rando := strings.ToLower(randStringBytesMaskImprSrcUnsafe(9))
 	buffer := bytes.NewBufferString(prefix)
 	buffer.WriteString(rando)
@@ -189,9 +188,9 @@ func setupKmsKey(sess *session.Session, prefix string) string {
 	} else {
 		fmt.Printf("Returning key: %q", returnkey)
 	}
-
+	newalias := "alias/" + aliasname
 	aliasreq, aliasresp := svc.CreateAliasRequest(&kms.CreateAliasInput{
-		AliasName:   aws.String(aliasname),
+		AliasName:   aws.String(newalias),
 		TargetKeyId: aws.String(string(returnkey)),
 	})
 
@@ -201,7 +200,7 @@ func setupKmsKey(sess *session.Session, prefix string) string {
 	} else {
 		fmt.Println(aliasresp)
 	}
-	return aliasname
+	return newalias
 }
 
 //emptyBucket empties the Amazon S3 bucket

--- a/integration/put_integration_test.go
+++ b/integration/put_integration_test.go
@@ -1,0 +1,310 @@
+package integration
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+var (
+	prefix     = "crossinggo"
+	bucketName = ""
+	key        = ""
+	source     = ""
+	kmsKey     = ""
+)
+
+//TestPutIntegration will test putS3Cse for a return value of a valid UTF-8 encoded version id
+func TestPutIntegration(t *testing.T) {
+
+}
+
+//SetupPut sets up an S3 Bucket, KMS key, and writes a file for Put integration testing
+func SetupPut() {
+
+	rando := strings.ToLower(randStringBytesMaskImprSrcUnsafe(9))
+	buffer := bytes.NewBufferString(prefix)
+	buffer.WriteString(rando)
+	bucketName = buffer.String()
+	key = "dat1"
+	source = "/tmp/dat1"
+
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-east-2")},
+	)
+
+	setUpBucket(sess, bucketName)
+	kmsKey = setupKmsKey(sess, prefix)
+
+	if err != nil {
+		exitErrorf("Unable to create session", err)
+	}
+
+}
+
+func exitErrorf(msg string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, msg+"\n", args...)
+	os.Exit(1)
+}
+
+func setUpBucket(sess *session.Session, bucketName string) {
+	svc := s3.New(sess)
+
+	_, err := svc.CreateBucket(&s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+
+	if err != nil {
+		exitErrorf("Unable to create bucket %q, %v", bucketName, err)
+	}
+
+	fmt.Printf("Waiting for bucket %q to be created...\n", bucketName)
+
+	err = svc.WaitUntilBucketExists(&s3.HeadBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+
+	if err != nil {
+		exitErrorf("Error occurred while waiting for bucket to be created, %v", bucketName)
+	}
+
+	fmt.Printf("Bucket %q successfully created\n", bucketName)
+
+	// Turn on versioning on the bucket
+	input := &s3.PutBucketVersioningInput{
+		Bucket: aws.String(bucketName),
+		VersioningConfiguration: &s3.VersioningConfiguration{
+			MFADelete: aws.String("Disabled"),
+			Status:    aws.String("Enabled"),
+		},
+	}
+
+	result, err := svc.PutBucketVersioning(input)
+
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				exitErrorf(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			exitErrorf("Setting versioning failed: %v", err.Error())
+		}
+		exitErrorf("Catastrophe! %v", err)
+	}
+
+	fmt.Printf("Successfully configured versioning %q", result)
+}
+
+func check(e error) {
+	if e != nil {
+		panic(e)
+	}
+}
+
+//Write a file to disk
+func createWriteFile() {
+	f, err := os.Create("/tmp/dat1")
+	check(err)
+
+	defer f.Close()
+
+	d1 := []byte{115, 111, 109, 101, 10}
+	n2, err := f.Write(d1)
+	check(err)
+	fmt.Printf("wrote %d bytes\n", n2)
+
+	f.Sync()
+}
+
+//Generate random postfix
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const (
+	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+)
+
+var src = rand.NewSource(time.Now().UnixNano())
+
+func randStringBytesMaskImprSrcUnsafe(n int) string {
+	b := make([]byte, n)
+	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = src.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return *(*string)(unsafe.Pointer(&b))
+}
+
+//Setup KMS key
+func setupKmsKey(sess *session.Session, prefix string) string {
+	rando := strings.ToLower(randStringBytesMaskImprSrcUnsafe(9))
+	buffer := bytes.NewBufferString(prefix)
+	buffer.WriteString(rando)
+	aliasname := buffer.String()
+
+	svc := kms.New(sess)
+
+	req, resp := svc.CreateKeyRequest(&kms.CreateKeyInput{
+		Tags: []*kms.Tag{
+			{
+				TagKey:   aws.String("crossinggokey"),
+				TagValue: aws.String("crossinggounittest"),
+			},
+		},
+	})
+
+	reqerr := req.Send()
+	if reqerr == nil {
+		fmt.Println(resp)
+	} else {
+		exitErrorf("Unable to create session", reqerr)
+	}
+	returnkey := *resp.KeyMetadata.KeyId
+
+	if reqerr != nil {
+		exitErrorf("Empty!", reqerr)
+	} else {
+		fmt.Printf("Returning key: %q", returnkey)
+	}
+
+	aliasreq, aliasresp := svc.CreateAliasRequest(&kms.CreateAliasInput{
+		AliasName:   aws.String(aliasname),
+		TargetKeyId: aws.String(string(returnkey)),
+	})
+
+	aliaserr := aliasreq.Send()
+	if aliaserr != nil {
+		exitErrorf("Error occured creating alias!", aliaserr)
+	} else {
+		fmt.Println(aliasresp)
+	}
+	return aliasname
+}
+
+//emptyBucket empties the Amazon S3 bucket
+func emptyBucket() {
+	sess, _ := session.NewSession(&aws.Config{
+		Region: aws.String("us-east-2")},
+	)
+
+	svc := s3.New(sess)
+
+	objectversions, err := svc.ListObjectVersions(&s3.ListObjectVersionsInput{
+		Bucket:    aws.String(bucketName),
+		KeyMarker: aws.String(key),
+	})
+
+	if err != nil {
+		exitErrorf("Listing error occurred: ", err)
+	}
+
+	versions := objectversions.Versions
+
+	for _, version := range versions {
+		req, resp := svc.DeleteObjectRequest(&s3.DeleteObjectInput{
+			Bucket:    aws.String(bucketName),
+			Key:       version.Key,
+			VersionId: version.VersionId,
+		})
+
+		err := req.Send()
+		if err != nil {
+			exitErrorf("Issue deleting: ", err)
+		} else {
+			fmt.Println("Deleted: ", resp)
+		}
+	}
+}
+
+func deleteBucket() {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-east-2")},
+	)
+
+	if err != nil {
+		exitErrorf("Unable to create session", err)
+	}
+
+	s3svc := s3.New(sess)
+
+	// Delete test bucket
+	s3buckreq, s3buckresp := s3svc.DeleteBucketRequest(&s3.DeleteBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+
+	s3buckerr := s3buckreq.Send()
+
+	if s3buckerr != nil {
+		fmt.Println("Error occurred deleting bucket: ", s3buckerr)
+		emptyBucket()
+	} else {
+		fmt.Println("Delete was successful", s3buckresp)
+	}
+}
+
+//PutCleanUp destroys all resources created for integration testing
+func PutCleanUp() {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-east-2")},
+	)
+	// Empty bucket
+	emptyBucket()
+
+	// Delete bucket
+	deleteBucket()
+
+	// Delete kms key
+	kmssvc := kms.New(sess)
+
+	keyoutput, err := kmssvc.DescribeKey(&kms.DescribeKeyInput{
+		KeyId: aws.String(kmsKey),
+	})
+
+	if err != nil {
+		exitErrorf("Describing key errored out: ", err)
+	}
+	keyid := *keyoutput.KeyMetadata.KeyId
+
+	kmsreq, kmsresp := kmssvc.ScheduleKeyDeletionRequest(&kms.ScheduleKeyDeletionInput{
+		KeyId:               aws.String(keyid),
+		PendingWindowInDays: aws.Int64(7),
+	})
+
+	kmserr := kmsreq.Send()
+
+	if kmserr != nil {
+		exitErrorf("Deleting key error occurred: ", kmserr)
+	} else {
+		fmt.Println("Key deletion scheduled: ", kmsresp)
+	}
+
+	// Delete file created for test
+	delerr := os.Remove("/tmp/dat1")
+
+	if delerr != nil {
+		exitErrorf("Deleting file error occurred: ", delerr)
+	}
+}

--- a/integration/put_integration_test.go
+++ b/integration/put_integration_test.go
@@ -51,16 +51,12 @@ func SetupPut() {
 	source = "/tmp/dat1"
 	createWriteFile()
 
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-east-2")},
-	)
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
 
 	setUpBucket(sess, bucketName)
 	kmsKey = setupKmsKey(sess)
-
-	if err != nil {
-		exitErrorf("Unable to create session", err)
-	}
 
 }
 
@@ -216,9 +212,9 @@ func setupKmsKey(sess *session.Session) string {
 
 //emptyBucket empties the Amazon S3 bucket
 func emptyBucket() {
-	sess, _ := session.NewSession(&aws.Config{
-		Region: aws.String("us-east-2")},
-	)
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
 
 	svc := s3.New(sess)
 
@@ -250,13 +246,9 @@ func emptyBucket() {
 }
 
 func deleteBucket() {
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-east-2")},
-	)
-
-	if err != nil {
-		exitErrorf("Unable to create session", err)
-	}
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
 
 	s3svc := s3.New(sess)
 
@@ -277,9 +269,9 @@ func deleteBucket() {
 
 //PutCleanUp destroys all resources created for integration testing
 func PutCleanUp() {
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-east-2")},
-	)
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
 	// Empty bucket
 	emptyBucket()
 


### PR DESCRIPTION
Composing structs with s3iface.S3API did not allow for objects to be encrypted. Adding interfaces to allow proper mocking of structs fix the issue of using s3iface.S3API and also allow for unit testing with mocks. 

Fixes issue #31 